### PR TITLE
Remove extra newline at end of WPT file for WPT Exporter testing

### DIFF
--- a/workers/semantics/multiple-workers/001.html
+++ b/workers/semantics/multiple-workers/001.html
@@ -38,4 +38,3 @@ async_test(function() {
 <!--
 */
 //-->
-

--- a/workers/semantics/xhr/003.html
+++ b/workers/semantics/xhr/003.html
@@ -38,4 +38,3 @@ function runtest() {
 <!--
 */
 //-->
-

--- a/workers/semantics/xhr/004.html
+++ b/workers/semantics/xhr/004.html
@@ -32,5 +32,3 @@ function runtest() {
 <!--
 */
 //-->
-
-


### PR DESCRIPTION
Remove extra newline at end of WPT file for WPT Exporter testing

Bug: 700092
Change-Id: I60d34bfc70741f03bff10453ce0934631f0df0cd
Reviewed-on: https://chromium-review.googlesource.com/479676
Cr-Commit-Position: refs/heads/master@{#466449}
WPT-Export-Revision: e032d07f8da65a34397b86707e3ade448b015d7e