### PR TITLE
Ensure Indexed DB tests clean up after themselves


### DIFF
--- a/IndexedDB/idb_webworkers.htm
+++ b/IndexedDB/idb_webworkers.htm
@@ -8,6 +8,7 @@
 <script>
     var db, count = 0,
       t = async_test();
+      t.add_cleanup(function() { indexedDB.deleteDatabase('webworker101'); });
 
     t.step(function() {
         var worker = new Worker("idbworker.js");
@@ -27,7 +28,4 @@
 
         worker.postMessage(1);
     })
-
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/idbcursor-advance-continue-async.htm
+++ b/IndexedDB/idbcursor-advance-continue-async.htm
@@ -7,180 +7,175 @@
 
 <script>
 
-    var db, open;
+function upgrade_func(t, db, tx) {
+  var objStore = db.createObjectStore("test");
+  objStore.createIndex("index", "");
 
-    setup(function() {
-        open = indexedDB.open('testdb-' + new Date().getTime());
-        open.onupgradeneeded = function(e) {
-            db = e.target.result;
-            var objStore = db.createObjectStore("test");
-            objStore.createIndex("index", "");
+  objStore.add("data",  1);
+  objStore.add("data2", 2);
+}
 
-            objStore.add("data",  1);
-            objStore.add("data2", 2);
-        };
-    },
-    { explicit_done: true });
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").openCursor();
 
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-    open.onsuccess = function() {
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "data")
+          assert_equals(cursor.key, 1)
+          cursor.advance(1)
+          assert_equals(cursor.value, "data")
+          assert_equals(cursor.key, 1)
+          break
 
+        case 1:
+          assert_equals(cursor.value, "data2")
+          assert_equals(cursor.key, 2)
+          cursor.advance(1)
+          assert_equals(cursor.value, "data2")
+          assert_equals(cursor.key, 2)
+          break
 
-        async_test(document.title + " - advance").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").openCursor();
+        default:
+          assert_unreached("Unexpected count: " + count)
+      }
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - advance"
+);
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "data")
-                        assert_equals(cursor.key, 1)
-                        cursor.advance(1)
-                        assert_equals(cursor.value, "data")
-                        assert_equals(cursor.key, 1)
-                        break
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-                    case 1:
-                        assert_equals(cursor.value, "data2")
-                        assert_equals(cursor.key, 2)
-                        cursor.advance(1)
-                        assert_equals(cursor.value, "data2")
-                        assert_equals(cursor.key, 2)
-                        break
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                    default:
-                        assert_unreached("Unexpected count: " + count)
-                }
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "data")
+          assert_equals(cursor.key,   "data")
+          assert_equals(cursor.primaryKey, 1)
+          cursor.continue("data2")
+          assert_equals(cursor.value, "data")
+          assert_equals(cursor.key,   "data")
+          assert_equals(cursor.primaryKey, 1)
+          break
 
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+        case 1:
+          assert_equals(cursor.value, "data2")
+          assert_equals(cursor.key,   "data2")
+          assert_equals(cursor.primaryKey, 2)
+          cursor.continue()
+          assert_equals(cursor.value, "data2")
+          assert_equals(cursor.key,   "data2")
+          assert_equals(cursor.primaryKey, 2)
+          break
 
+        default:
+          assert_unreached("Unexpected count: " + count)
+      }
 
-        async_test(document.title + " - continue").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - continue"
+);
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "data")
-                        assert_equals(cursor.key,   "data")
-                        assert_equals(cursor.primaryKey, 1)
-                        cursor.continue("data2")
-                        assert_equals(cursor.value, "data")
-                        assert_equals(cursor.key,   "data")
-                        assert_equals(cursor.primaryKey, 1)
-                        break
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
+      cursor.advance(1)
 
-                    case 1:
-                        assert_equals(cursor.value, "data2")
-                        assert_equals(cursor.key,   "data2")
-                        assert_equals(cursor.primaryKey, 2)
-                        cursor.continue()
-                        assert_equals(cursor.value, "data2")
-                        assert_equals(cursor.key,   "data2")
-                        assert_equals(cursor.primaryKey, 2)
-                        break
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "data")
+          assert_equals(cursor.key,   "data")
+          assert_equals(cursor.primaryKey, 1)
+          break
 
-                    default:
-                        assert_unreached("Unexpected count: " + count)
-                }
+        case 1:
+          assert_equals(cursor.value, "data2")
+          assert_equals(cursor.key,   "data2")
+          assert_equals(cursor.primaryKey, 2)
+          break
 
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+        default:
+          assert_unreached("Unexpected count: " + count)
+      }
 
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - fresh advance still async"
+);
 
-        async_test(document.title + " - fresh advance still async").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").openCursor();
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
-                cursor.advance(1)
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
+      cursor.continue()
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "data")
-                        assert_equals(cursor.key,   "data")
-                        assert_equals(cursor.primaryKey, 1)
-                        break
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "data")
+          assert_equals(cursor.key, 1)
+          break
 
-                    case 1:
-                        assert_equals(cursor.value, "data2")
-                        assert_equals(cursor.key,   "data2")
-                        assert_equals(cursor.primaryKey, 2)
-                        break
+        case 1:
+          assert_equals(cursor.value, "data2")
+          assert_equals(cursor.key, 2)
+          break
 
-                    default:
-                        assert_unreached("Unexpected count: " + count)
-                }
+        default:
+          assert_unreached("Unexpected count: " + count)
+      }
 
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
-
-
-        async_test(document.title + " - fresh continue still async").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").openCursor();
-
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
-                cursor.continue()
-
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "data")
-                        assert_equals(cursor.key, 1)
-                        break
-
-                    case 1:
-                        assert_equals(cursor.value, "data2")
-                        assert_equals(cursor.key, 2)
-                        break
-
-                    default:
-                        assert_unreached("Unexpected count: " + count)
-                }
-
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
-
-        // Stop blocking the testing system from hereon
-        done();
-    }
-
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - fresh continue still async"
+);
 </script>
-
-<div id=log></div>

--- a/IndexedDB/idbcursor-advance-invalid.htm
+++ b/IndexedDB/idbcursor-advance-invalid.htm
@@ -13,176 +13,180 @@
 
 <script>
 
-    var db, open;
+function upgrade_func(t, db, tx) {
+  var objStore = db.createObjectStore("test");
+  objStore.createIndex("index", "");
 
-    setup(function() {
-        open = indexedDB.open('testdb-' + new Date().getTime());
-        open.onupgradeneeded = function(e) {
-            db = e.target.result;
-            var objStore = db.createObjectStore("test");
-            objStore.createIndex("index", "");
+  objStore.add("data",  1);
+  objStore.add("data2", 2);
+}
 
-            objStore.add("data",  1);
-            objStore.add("data2", 2);
-        };
-    },
-    { explicit_done: true });
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-    open.onsuccess = function() {
+      cursor.advance(1);
 
-        async_test(document.title + " - attempt to call advance twice").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
-
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
-
-                cursor.advance(1);
-
-                // Second try
-                assert_throws('InvalidStateError',
+      // Second try
+      assert_throws('InvalidStateError',
                     function() { cursor.advance(1); }, 'second advance');
 
-                assert_throws('InvalidStateError',
+      assert_throws('InvalidStateError',
                     function() { cursor.advance(3); }, 'third advance');
 
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - attempt to call advance twice"
+);
 
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-        async_test(document.title + " - pass something other than number").step(function(e) {
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+    rq.onsuccess = t.step_func(function(e) {
+      var cursor = e.target.result;
 
-            rq.onsuccess = this.step_func(function(e) {
-                var cursor = e.target.result;
-
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(document); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance({}); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance([]); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(""); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance("1 2"); });
 
-                this.done();
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      t.done();
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - pass something other than number"
+);
 
 
-        async_test(document.title + " - pass null/undefined").step(function(e) {
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-            rq.onsuccess = this.step_func(function(e) {
-                var cursor = e.target.result;
+    rq.onsuccess = t.step_func(function(e) {
+      var cursor = e.target.result;
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(null); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(undefined); });
 
-                var myvar = null;
-                assert_throws({ name: "TypeError" },
+      var myvar = null;
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(myvar); });
 
-                this.done();
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      t.done();
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - pass null/undefined"
+);
 
 
-        async_test(document.title + " - missing argument").step(function(e) {
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-            rq.onsuccess = this.step_func(function(e) {
-                var cursor = e.target.result;
+    rq.onsuccess = t.step_func(function(e) {
+      var cursor = e.target.result;
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(); });
 
-                this.done();
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      t.done();
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - missing argument"
+);
 
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-        async_test(document.title + " - pass negative numbers").step(function(e) {
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+    rq.onsuccess = t.step_func(function(e) {
+      var cursor = e.target.result;
 
-            rq.onsuccess = this.step_func(function(e) {
-                var cursor = e.target.result;
-
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(-1); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(NaN); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(0); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(-0); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(Infinity); });
 
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(-Infinity); });
 
-                var myvar = -999999;
-                assert_throws({ name: "TypeError" },
+      var myvar = -999999;
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(myvar); });
 
-                this.done();
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      t.done();
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - pass negative numbers"
+);
 
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-        async_test(document.title + " - got value not set on exception").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+    rq.onsuccess = t.step_func(function(e) {
+      var cursor = e.target.result;
+      if (!cursor)
+        {
+          assert_equals(count, 2, "count runs");
+          t.done();
+          return;
+        }
 
-            rq.onsuccess = this.step_func(function(e) {
-                var cursor = e.target.result;
-                if (!cursor)
-                {
-                    assert_equals(count, 2, "count runs");
-                    this.done();
-                    return;
-                }
-
-                assert_throws({ name: "TypeError" },
+      assert_throws({ name: "TypeError" },
                     function() { cursor.advance(0); });
 
-                cursor.advance(1);
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
-
-
-        // Stop blocking the testing system from hereon
-        done();
-    }
+      cursor.advance(1);
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - got value not set on exception"
+);
 
 </script>
-
-<div id=log></div>

--- a/IndexedDB/idbcursor-advance.htm
+++ b/IndexedDB/idbcursor-advance.htm
@@ -7,237 +7,241 @@
 
 <script>
 
-    var db, open;
+function upgrade_func(t, db, tx) {
+  var objStore = db.createObjectStore("test");
+  objStore.createIndex("index", "");
 
-    setup(function() {
-        open = indexedDB.open("testdb-" + new Date().getTime());
-        open.onupgradeneeded = function(e) {
-            db = e.target.result;
-            var objStore = db.createObjectStore("test");
-            objStore.createIndex("index", "");
+  objStore.add("cupcake", 5);
+  objStore.add("pancake", 3); // Yes, it is intended
+  objStore.add("pie",     1);
+  objStore.add("pie",     4);
+  objStore.add("taco",    2);
+}
 
-            objStore.add("cupcake", 5);
-            objStore.add("pancake", 3); // Yes, it is intended
-            objStore.add("pie",     1);
-            objStore.add("pie",     4);
-            objStore.add("taco",    2);
-        };
-    },
-    { explicit_done: true });
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 3, "count");
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-    open.onsuccess = function() {
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "cupcake");
+          assert_equals(cursor.primaryKey, 5);
+          break;
 
-        async_test(document.title + " - advances").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+        case 1:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 1);
+          break;
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 3, "count");
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+        case 2:
+          assert_equals(cursor.value, "taco");
+          assert_equals(cursor.primaryKey, 2);
+          break;
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "cupcake");
-                        assert_equals(cursor.primaryKey, 5);
-                        break;
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-                    case 1:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 1);
-                        break;
+      count++;
+      cursor.advance(2);
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - advances"
+);
 
-                    case 2:
-                        assert_equals(cursor.value, "taco");
-                        assert_equals(cursor.primaryKey, 2);
-                        break;
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor(null, "prev");
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 3, "count");
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                count++;
-                cursor.advance(2);
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "taco");
+          assert_equals(cursor.primaryKey, 2);
+          break;
 
-        async_test(document.title + " - advances backwards").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor(null, "prev");
+        case 1:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 1);
+          break;
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 3, "count");
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+        case 2:
+          assert_equals(cursor.value, "cupcake");
+          assert_equals(cursor.primaryKey, 5);
+          break;
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "taco");
-                        assert_equals(cursor.primaryKey, 2);
-                        break;
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-                    case 1:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 1);
-                        break;
+      count++;
+      cursor.advance(2);
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - advances backwards"
+);
 
-                    case 2:
-                        assert_equals(cursor.value, "cupcake");
-                        assert_equals(cursor.primaryKey, 5);
-                        break;
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor();
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 1, "count");
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                count++;
-                cursor.advance(2);
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "cupcake");
+          assert_equals(cursor.primaryKey, 5);
+          break;
 
-        async_test(document.title + " - skip far forward").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor();
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 1, "count");
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+      count++;
+      cursor.advance(100000);
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - skip far forward"
+);
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "cupcake");
-                        assert_equals(cursor.primaryKey, 5);
-                        break;
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor(IDBKeyRange.lowerBound("cupcake", true));
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, "count");
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                count++;
-                cursor.advance(100000);
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "pancake");
+          assert_equals(cursor.primaryKey, 3);
+          break;
 
+        case 1:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 4);
+          break;
 
-        async_test(document.title + " - within range").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor(IDBKeyRange.lowerBound("cupcake", true));
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, "count");
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+      count++;
+      cursor.advance(2);
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - within range"
+);
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "pancake");
-                        assert_equals(cursor.primaryKey, 3);
-                        break;
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor("pancake");
 
-                    case 1:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 4);
-                        break;
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 1, "count");
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "pancake");
+          assert_equals(cursor.primaryKey, 3);
+          break;
 
-                count++;
-                cursor.advance(2);
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
+      count++;
+      cursor.advance(1);
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - within single key range"
+);
 
-        async_test(document.title + " - within single key range").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor("pancake");
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor("pie");
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 1, "count");
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, "count");
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "pancake");
-                        assert_equals(cursor.primaryKey, 3);
-                        break;
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 1);
+          break;
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+        case 1:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 4);
+          break;
 
-                count++;
-                cursor.advance(1);
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-
-        async_test(document.title + " - within single key range, with several results").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor("pie");
-
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, "count");
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
-
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 1);
-                        break;
-
-                    case 1:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 4);
-                        break;
-
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
-
-                count++;
-                cursor.advance(1);
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
-
-
-        // Stop blocking the testing system from hereon
-        done();
-    }
+      count++;
+      cursor.advance(1);
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - within single key range, with several results"
+);
 
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/idbcursor-continue.htm
+++ b/IndexedDB/idbcursor-continue.htm
@@ -9,232 +9,240 @@
 
 <script>
 
-    var db, open;
-    var store = [ { value: "cupcake", key: 5 },
-                  { value: "pancake", key: 3 },
-                  { value: "pie",     key: 1 },
-                  { value: "pie",     key: 4 },
-                  { value: "taco",    key: 2 } ];
+var store = [ { value: "cupcake", key: 5 },
+              { value: "pancake", key: 3 },
+              { value: "pie",     key: 1 },
+              { value: "pie",     key: 4 },
+              { value: "taco",    key: 2 } ];
 
-    setup(function() {
-        open = indexedDB.open('testdb-' + new Date().getTime());
-        open.onupgradeneeded = function(e) {
-            var os, i;
-            db = e.target.result;
-            os = db.createObjectStore("test");
-            os.createIndex("index", "");
+function upgrade_func(t, db, tx) {
+  var db, open;
 
-            for (i = 0; i < store.length; i++)
-                os.add(store[i].value, store[i].key);
-        };
-    },
-    { explicit_done: true });
+  var os, i;
+  os = db.createObjectStore("test");
+  os.createIndex("index", "");
 
+  for (i = 0; i < store.length; i++)
+    os.add(store[i].value, store[i].key);
+}
 
-    open.onsuccess = function() {
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 5, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-        async_test(document.title + " - continues").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+      assert_equals(cursor.value, store[count].value);
+      assert_equals(cursor.primaryKey, store[count].key);
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 5, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+      cursor.continue();
 
-                assert_equals(cursor.value, store[count].value);
-                assert_equals(cursor.primaryKey, store[count].key);
-
-                cursor.continue();
-
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - continues"
+);
 
 
-        async_test(document.title + " - with given key").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index").openCursor();
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index").openCursor();
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 3, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 3, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "cupcake");
-                        assert_equals(cursor.primaryKey, 5);
-                        cursor.continue("pie");
-                        break;
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "cupcake");
+          assert_equals(cursor.primaryKey, 5);
+          cursor.continue("pie");
+          break;
 
-                    case 1:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 1);
-                        cursor.continue("taco");
-                        break;
+        case 1:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 1);
+          cursor.continue("taco");
+          break;
 
-                    case 2:
-                        assert_equals(cursor.value, "taco");
-                        assert_equals(cursor.primaryKey, 2);
-                        cursor.continue();
-                        break;
+        case 2:
+          assert_equals(cursor.value, "taco");
+          assert_equals(cursor.primaryKey, 2);
+          cursor.continue();
+          break;
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error")
-        });
-
-
-        async_test(document.title + " - skip far forward").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor();
-
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 1, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
-
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "cupcake");
-                        assert_equals(cursor.primaryKey, 5);
-                        break;
-
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
-
-                count++;
-                cursor.continue([]); // Arrays are always bigger than strings
-
-            });
-            rq.onerror = fail(this, "unexpected error2")
-        });
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error")
+  },
+  document.title + " - with given key"
+);
 
 
-        async_test(document.title + " - within range").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor(IDBKeyRange.lowerBound("cupcake", true));
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor();
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 1, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "pancake");
-                        assert_equals(cursor.primaryKey, 3);
-                        cursor.continue("pie");
-                        break;
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "cupcake");
+          assert_equals(cursor.primaryKey, 5);
+          break;
 
-                    case 1:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 1);
-                        cursor.continue("zzz");
-                        break;
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+      count++;
+      cursor.continue([]); // Arrays are always bigger than strings
 
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error1")
-        });
-
-
-        async_test(document.title + " - within single key range").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor("pancake");
-
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 1, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
-
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "pancake");
-                        assert_equals(cursor.primaryKey, 3);
-                        cursor.continue("pie");
-                        break;
-
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
-
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error1")
-        });
+    });
+    rq.onerror = t.unreached_func("unexpected error2")
+  },
+  document.title + " - skip far forward"
+);
 
 
-        async_test(document.title + " - within single key range, with several results").step(function(e) {
-            var count = 0;
-            var rq = db.transaction("test").objectStore("test").index("index")
-                       .openCursor("pie");
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor(IDBKeyRange.lowerBound("cupcake", true));
 
-            rq.onsuccess = this.step_func(function(e) {
-                if (!e.target.result) {
-                    assert_equals(count, 2, 'count');
-                    this.done();
-                    return;
-                }
-                var cursor = e.target.result;
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
 
-                switch(count) {
-                    case 0:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 1);
-                        cursor.continue();
-                        break;
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "pancake");
+          assert_equals(cursor.primaryKey, 3);
+          cursor.continue("pie");
+          break;
 
-                    case 1:
-                        assert_equals(cursor.value, "pie");
-                        assert_equals(cursor.primaryKey, 4);
-                        cursor.continue();
-                        break;
+        case 1:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 1);
+          cursor.continue("zzz");
+          break;
 
-                    default:
-                        assert_unreached("Unexpected count: " + count);
-                }
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
 
-                count++;
-            });
-            rq.onerror = fail(this, "unexpected error1")
-        });
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error1")
+  },
+  document.title + " - within range"
+);
 
 
-        // Stop blocking the testing system from hereon
-        done();
-    }
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor("pancake");
+
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 1, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
+
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "pancake");
+          assert_equals(cursor.primaryKey, 3);
+          cursor.continue("pie");
+          break;
+
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
+
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error1")
+  },
+  document.title + " - within single key range"
+);
+
+indexeddb_test(
+  upgrade_func,
+  function(t, db) {
+    var count = 0;
+    var rq = db.transaction("test").objectStore("test").index("index")
+               .openCursor("pie");
+
+    rq.onsuccess = t.step_func(function(e) {
+      if (!e.target.result) {
+        assert_equals(count, 2, 'count');
+        t.done();
+        return;
+      }
+      var cursor = e.target.result;
+
+      switch(count) {
+        case 0:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 1);
+          cursor.continue();
+          break;
+
+        case 1:
+          assert_equals(cursor.value, "pie");
+          assert_equals(cursor.primaryKey, 4);
+          cursor.continue();
+          break;
+
+        default:
+          assert_unreached("Unexpected count: " + count);
+      }
+
+      count++;
+    });
+    rq.onerror = t.unreached_func("unexpected error1")
+  },
+  document.title + " - within single key range, with several results"
+);
 
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/idbcursor-continuePrimaryKey-exception-order.htm
+++ b/IndexedDB/idbcursor-continuePrimaryKey-exception-order.htm
@@ -45,12 +45,12 @@ indexeddb_test(
 
             store.deleteIndex("idx");
         });
-        txn.oncomplete = function() {
+        txn.oncomplete = t.step_func(function() {
             assert_throws("TransactionInactiveError", function() {
                 cursor.continuePrimaryKey("A", 4);
             }, "transaction-state check should precede deletion check");
             t.done();
-        };
+        });
     },
     null,
     "TransactionInactiveError v.s. InvalidStateError(deleted index)"
@@ -378,5 +378,3 @@ indexeddb_test(
     "DataError(keys are larger then current one) in 'prev' direction"
 );
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/idbcursor-continuePrimaryKey-exceptions.htm
+++ b/IndexedDB/idbcursor-continuePrimaryKey-exceptions.htm
@@ -16,6 +16,10 @@ async_test(function(t) {
 
     open.onupgradeneeded = t.step_func(function() {
         var db = open.result;
+        t.add_cleanup(function() {
+            db.close();
+            indexedDB.deleteDatabase(db.name);
+        });
         var store = db.createObjectStore('store');
         store.put('a', 1).onerror = t.unreached_func('put should not fail');
         var request = store.openCursor();
@@ -60,6 +64,10 @@ async_test(function(t) {
 
         open.onupgradeneeded = t.step_func(function() {
             var db = open.result;
+            t.add_cleanup(function() {
+                db.close();
+                indexedDB.deleteDatabase(db.name);
+            });
             var store = db.createObjectStore('store', {keyPath: 'pk'});
             var index = store.createIndex('index', 'ik', {multiEntry: true});
             store.put({pk: 'a', ik: [1,2,3]}).onerror =

--- a/IndexedDB/idbcursor-direction-index-keyrange.htm
+++ b/IndexedDB/idbcursor-direction-index-keyrange.htm
@@ -15,69 +15,46 @@
 <script src="support.js"></script>
 
 <script>
-    var records = [ 1337, "Alice", "Bob", "Bob", "Greg", "Åke", ["Anne"] ];
-    var directions = ["next", "prev", "nextunique", "prevunique"];
-    var tests = {};
-
-    directions.forEach(function(dir) {
-        tests[dir] = async_test(document.title + ' - ' + dir);
-    });
-
-    var open_rq = indexedDB.open("testdb-" + new Date().getTime() + Math.random());
-
-    open_rq.onupgradeneeded = function(e) {
-        var objStore = e.target.result.createObjectStore("test");
-        objStore.createIndex("idx", "name");
-
-        for (var i = 0; i < records.length; i++)
-            objStore.add({ name: records[i] }, i);
-    };
-
-    open_rq.onsuccess = function(e) {
-        var db = e.target.result;
-        db.onerror = fail_helper("db.onerror");
+var records = [ 1337, "Alice", "Bob", "Bob", "Greg", "Åke", ["Anne"] ];
+var cases = [
+  {dir: 'next', expect: ['Alice:1', 'Bob:2', 'Bob:3', 'Greg:4']},
+  {dir: 'prev', expect: ['Greg:4',  'Bob:3', 'Bob:2', 'Alice:1']},
+  {dir: 'nextunique', expect: ['Alice:1', 'Bob:2', 'Greg:4']},
+  {dir: 'prevunique', expect: ['Greg:4',  'Bob:2', 'Alice:1']}
+];
 
 
-        // The tests
-        testdir('next',       ['Alice:1', 'Bob:2', 'Bob:3', 'Greg:4']);
-        testdir('prev',       ['Greg:4',  'Bob:3', 'Bob:2', 'Alice:1']);
-        testdir('nextunique', ['Alice:1', 'Bob:2', 'Greg:4']);
-        testdir('prevunique', ['Greg:4',  'Bob:2', 'Alice:1']);
+cases.forEach(function(testcase) {
+  var dir = testcase.dir;
+  var expect = testcase.expect;
+  indexeddb_test(
+    function(t, db, tx) {
+      var objStore = db.createObjectStore("test");
+      objStore.createIndex("idx", "name");
 
-
-        // Test function
-        function testdir(dir, expect) {
-            var count = 0;
-            var t = tests[dir];
-            var rq = db.transaction("test").objectStore("test").index("idx").openCursor(IDBKeyRange.bound("AA", "ZZ"), dir);
-            rq.onsuccess = t.step_func(function(e) {
-                var cursor = e.target.result;
-                if (!cursor) {
-                    assert_equals(count, expect.length, "cursor runs");
-                    t.done();
-                }
-                assert_equals(cursor.value.name + ":" + cursor.primaryKey, expect[count], "cursor.value");
-                count++;
-                cursor.continue();
-            });
-            rq.onerror = t.step_func(function(e) {
-                e.preventDefault();
-                e.stopPropagation();
-                assert_unreached("rq.onerror - " + e.message);
-            });
+      for (var i = 0; i < records.length; i++)
+        objStore.add({ name: records[i] }, i);
+    },
+    function(t, db) {
+      var count = 0;
+      var rq = db.transaction("test").objectStore("test").index("idx").openCursor(IDBKeyRange.bound("AA", "ZZ"), dir);
+      rq.onsuccess = t.step_func(function(e) {
+        var cursor = e.target.result;
+        if (!cursor) {
+          assert_equals(count, expect.length, "cursor runs");
+          t.done();
         }
-    };
-
-    // Fail handling
-    function fail_helper(name) {
-        return function() {
-            directions.forEach(function(dir) {
-                tests[dir].step(function() { assert_unreached(name); });
-            });
-        };
-    }
-    open_rq.onblocked = fail_helper('open_rq.onblocked');
-    open_rq.onerror = fail_helper('open_rq.onerror');
+        assert_equals(cursor.value.name + ":" + cursor.primaryKey, expect[count], "cursor.value");
+        count++;
+        cursor.continue();
+      });
+      rq.onerror = t.step_func(function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        assert_unreached("rq.onerror - " + e.message);
+      });
+    },
+    document.title + ' - ' + dir
+  )
+});
 </script>
-
-<div id=log> </div>

--- a/IndexedDB/idbcursor-direction-index.htm
+++ b/IndexedDB/idbcursor-direction-index.htm
@@ -13,69 +13,45 @@
 <script src="support.js"></script>
 
 <script>
-    var records = [ "Alice", "Bob", "Bob", "Greg" ];
-    var directions = ["next", "prev", "nextunique", "prevunique"];
-    var tests = {};
+var records = [ "Alice", "Bob", "Bob", "Greg" ];
+var cases = [
+  {dir: 'next', expect: ['Alice:0', 'Bob:1', 'Bob:2', 'Greg:3']},
+  {dir: 'prev', expect: ['Greg:3',  'Bob:2', 'Bob:1', 'Alice:0']},
+  {dir: 'nextunique', expect: ['Alice:0', 'Bob:1', 'Greg:3']},
+  {dir: 'prevunique', expect: ['Greg:3',  'Bob:1', 'Alice:0']},
+];
 
-    directions.forEach(function(dir) {
-        tests[dir] = async_test(document.title + ' - ' + dir);
-    });
+cases.forEach(function(testcase) {
+  var dir = testcase.dir;
+  var expect = testcase.expect;
+  indexeddb_test(
+    function(t, db, tx) {
+      var objStore = db.createObjectStore("test");
+      objStore.createIndex("idx", "name");
 
-    var open_rq = indexedDB.open("testdb-" + new Date().getTime() + Math.random());
-
-    open_rq.onupgradeneeded = function(e) {
-        var objStore = e.target.result.createObjectStore("test");
-        objStore.createIndex("idx", "name");
-
-        for (var i = 0; i < records.length; i++)
-            objStore.add({ name: records[i] }, i);
-    };
-
-    open_rq.onsuccess = function(e) {
-        var db = e.target.result;
-        db.onerror = fail_helper("db.onerror");
-
-
-        // The tests
-        testdir('next',       ['Alice:0', 'Bob:1', 'Bob:2', 'Greg:3']);
-        testdir('prev',       ['Greg:3',  'Bob:2', 'Bob:1', 'Alice:0']);
-        testdir('nextunique', ['Alice:0', 'Bob:1', 'Greg:3']);
-        testdir('prevunique', ['Greg:3',  'Bob:1', 'Alice:0']);
-
-
-        // Test function
-        function testdir(dir, expect) {
-            var count = 0;
-            var t = tests[dir];
-            var rq = db.transaction("test").objectStore("test").index("idx").openCursor(undefined, dir);
-            rq.onsuccess = t.step_func(function(e) {
-                var cursor = e.target.result;
-                if (!cursor) {
-                    assert_equals(count, expect.length, "cursor runs");
-                    t.done();
-                }
-                assert_equals(cursor.value.name + ":" + cursor.primaryKey, expect[count], "cursor.value");
-                count++;
-                cursor.continue();
-            });
-            rq.onerror = t.step_func(function(e) {
-                e.preventDefault();
-                e.stopPropagation();
-                assert_unreached("rq.onerror - " + e.message);
-            });
+      for (var i = 0; i < records.length; i++)
+        objStore.add({ name: records[i] }, i);
+    },
+    function(t, db) {
+      var count = 0;
+      var rq = db.transaction("test").objectStore("test").index("idx").openCursor(undefined, dir);
+      rq.onsuccess = t.step_func(function(e) {
+        var cursor = e.target.result;
+        if (!cursor) {
+          assert_equals(count, expect.length, "cursor runs");
+          t.done();
         }
-    };
-
-    // Fail handling
-    function fail_helper(name) {
-        return function() {
-            directions.forEach(function(dir) {
-                tests[dir].step(function() { assert_unreached(name); });
-            });
-        };
-    }
-    open_rq.onblocked = fail_helper('open_rq.onblocked');
-    open_rq.onerror = fail_helper('open_rq.onerror');
+        assert_equals(cursor.value.name + ":" + cursor.primaryKey, expect[count], "cursor.value");
+        count++;
+        cursor.continue();
+      });
+      rq.onerror = t.step_func(function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        assert_unreached("rq.onerror - " + e.message);
+      });
+    },
+    document.title + ' - ' + dir
+  );
+});
 </script>
-
-<div id=log> </div>

--- a/IndexedDB/idbcursor-direction-objectstore-keyrange.htm
+++ b/IndexedDB/idbcursor-direction-objectstore-keyrange.htm
@@ -11,68 +11,44 @@
 <script src="support.js"></script>
 
 <script>
-    var records = [ 1337, "Alice", "Bob", "Greg", "Åke", ["Anne"] ];
-    var directions = ["next", "prev", "nextunique", "prevunique"];
-    var tests = {};
+var records = [ 1337, "Alice", "Bob", "Greg", "Åke", ["Anne"] ];
+var directions = ["next", "prev", "nextunique", "prevunique"];
+var cases = [
+  {dir: 'next', expect: ['Alice', 'Bob', 'Greg']},
+  {dir: 'prev', expect: ['Greg', 'Bob', 'Alice']},
+  {dir: 'nextunique', expect: ['Alice', 'Bob', 'Greg']},
+  {dir: 'prevunique', expect: ['Greg', 'Bob', 'Alice']},
+];
 
-    directions.forEach(function(dir) {
-        tests[dir] = async_test(document.title + ' - ' + dir);
-    });
-
-    var open_rq = indexedDB.open("testdb-" + new Date().getTime() + Math.random());
-
-    open_rq.onupgradeneeded = function(e) {
-        var objStore = e.target.result.createObjectStore("test");
-
+cases.forEach(function(testcase) {
+  var dir = testcase.dir;
+  var expect = testcase.expect;
+  indexeddb_test(
+    function(t, db, tx) {
+        var objStore = db.createObjectStore("test");
         for (var i = 0; i < records.length; i++)
-            objStore.add(records[i], records[i]);
-    };
-
-    open_rq.onsuccess = function(e) {
-        var db = e.target.result;
-        db.onerror = fail_helper("db.onerror");
-
-
-        // The tests
-        testdir('next',       ['Alice', 'Bob', 'Greg']);
-        testdir('prev',       ['Greg', 'Bob', 'Alice']);
-        testdir('nextunique', ['Alice', 'Bob', 'Greg']);
-        testdir('prevunique', ['Greg', 'Bob', 'Alice']);
-
-
-        // Test function
-        function testdir(dir, expect) {
-            var count = 0;
-            var t = tests[dir];
-            var rq = db.transaction("test").objectStore("test").openCursor(IDBKeyRange.bound("AA", "ZZ"), dir);
-            rq.onsuccess = t.step_func(function(e) {
-                var cursor = e.target.result;
-                if (!cursor) {
-                    assert_equals(count, expect.length, "cursor runs");
-                    t.done();
-                }
-                assert_equals(cursor.value, expect[count], "cursor.value");
-                count++;
-                cursor.continue();
-            });
-            rq.onerror = t.step_func(function(e) {
-                e.preventDefault();
-                e.stopPropagation();
-                assert_unreached("rq.onerror - " + e.message);
-            });
+          objStore.add(records[i], records[i]);
+    },
+    function(t, db) {
+      var count = 0;
+      var rq = db.transaction("test").objectStore("test").openCursor(IDBKeyRange.bound("AA", "ZZ"), dir);
+      rq.onsuccess = t.step_func(function(e) {
+        var cursor = e.target.result;
+        if (!cursor) {
+          assert_equals(count, expect.length, "cursor runs");
+          t.done();
         }
-    };
-
-    // Fail handling
-    function fail_helper(name) {
-        return function() {
-            directions.forEach(function(dir) {
-                tests[dir].step(function() { assert_unreached(name); });
-            });
-        };
-    }
-    open_rq.onblocked = fail_helper('open_rq.onblocked');
-    open_rq.onerror = fail_helper('open_rq.onerror');
+        assert_equals(cursor.value, expect[count], "cursor.value");
+        count++;
+        cursor.continue();
+      });
+      rq.onerror = t.step_func(function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        assert_unreached("rq.onerror - " + e.message);
+      });
+    },
+    document.title + ' - ' + dir
+  );
+});
 </script>
-
-<div id=log> </div>

--- a/IndexedDB/idbcursor-direction-objectstore.htm
+++ b/IndexedDB/idbcursor-direction-objectstore.htm
@@ -13,68 +13,44 @@
 <script src="support.js"></script>
 
 <script>
-    var records = [ "Alice", "Bob", "Greg" ];
-    var directions = ["next", "prev", "nextunique", "prevunique"];
-    var tests = {};
+var records = [ "Alice", "Bob", "Greg" ];
+var directions = ["next", "prev", "nextunique", "prevunique"];
+var cases = [
+  {dir: 'next', expect: ['Alice', 'Bob', 'Greg']},
+  {dir: 'prev', expect: ['Greg', 'Bob', 'Alice']},
+  {dir: 'nextunique', expect: ['Alice', 'Bob', 'Greg']},
+  {dir: 'prevunique', expect: ['Greg', 'Bob', 'Alice']},
+];
 
-    directions.forEach(function(dir) {
-        tests[dir] = async_test(document.title + ' - ' + dir);
-    });
-
-    var open_rq = indexedDB.open("testdb-" + new Date().getTime() + Math.random());
-
-    open_rq.onupgradeneeded = function(e) {
-        var objStore = e.target.result.createObjectStore("test");
-
-        for (var i = 0; i < records.length; i++)
-            objStore.add(records[i], records[i]);
-    };
-
-    open_rq.onsuccess = function(e) {
-        var db = e.target.result;
-        db.onerror = fail_helper("db.onerror");
-
-
-        // The tests
-        testdir('next',       ['Alice', 'Bob', 'Greg']);
-        testdir('prev',       ['Greg', 'Bob', 'Alice']);
-        testdir('nextunique', ['Alice', 'Bob', 'Greg']);
-        testdir('prevunique', ['Greg', 'Bob', 'Alice']);
-
-
-        // Test function
-        function testdir(dir, expect) {
-            var count = 0;
-            var t = tests[dir];
-            var rq = db.transaction("test").objectStore("test").openCursor(undefined, dir);
-            rq.onsuccess = t.step_func(function(e) {
-                var cursor = e.target.result;
-                if (!cursor) {
-                    assert_equals(count, expect.length, "cursor runs");
-                    t.done();
-                }
-                assert_equals(cursor.value, expect[count], "cursor.value");
-                count++;
-                cursor.continue();
-            });
-            rq.onerror = t.step_func(function(e) {
-                e.preventDefault();
-                e.stopPropagation();
-                assert_unreached("rq.onerror - " + e.message);
-            });
+cases.forEach(function(testcase) {
+  var dir = testcase.dir;
+  var expect = testcase.expect;
+  indexeddb_test(
+    function(t, db, tx) {
+      var objStore = db.createObjectStore("test");
+      for (var i = 0; i < records.length; i++)
+        objStore.add(records[i], records[i]);
+    },
+    function(t, db) {
+      var count = 0;
+      var rq = db.transaction("test").objectStore("test").openCursor(undefined, dir);
+      rq.onsuccess = t.step_func(function(e) {
+        var cursor = e.target.result;
+        if (!cursor) {
+          assert_equals(count, expect.length, "cursor runs");
+          t.done();
         }
-    };
-
-    // Fail handling
-    function fail_helper(name) {
-        return function() {
-            directions.forEach(function(dir) {
-                tests[dir].step(function() { assert_unreached(name); });
-            });
-        };
-    }
-    open_rq.onblocked = fail_helper('open_rq.onblocked');
-    open_rq.onerror = fail_helper('open_rq.onerror');
+        assert_equals(cursor.value, expect[count], "cursor.value");
+        count++;
+        cursor.continue();
+      });
+      rq.onerror = t.step_func(function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        assert_unreached("rq.onerror - " + e.message);
+      });
+    },
+    document.title + ' - ' + dir
+  );
+});
 </script>
-
-<div id=log> </div>

--- a/IndexedDB/idbcursor-direction.htm
+++ b/IndexedDB/idbcursor-direction.htm
@@ -17,6 +17,11 @@
 
         open_rq.onupgradeneeded = function(e) {
             db = e.target.result;
+            t.add_cleanup(function() {
+                db.close();
+                indexedDB.deleteDatabase(db.name);
+            });
+
             var objStore = db.createObjectStore("test");
 
             objStore.add("data", "key");
@@ -69,5 +74,3 @@
     cursor_direction("prevunique", "prevunique");
 
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/idbcursor-source.htm
+++ b/IndexedDB/idbcursor-source.htm
@@ -6,63 +6,61 @@
 <script src="support.js"></script>
 
 <script>
-    setup({ explicit_done: true });
+function cursor_source_test(test_name, name, stringified_object, cursor_rq_func) {
+  indexeddb_test(
+    function(t, db, tx) {
+      var objStore = db.createObjectStore("my_objectstore");
+      objStore.createIndex("my_index", "");
 
-    var db;
-    var open_rq = indexedDB.open('testdb-' + new Date().getTime());
-    open_rq.onupgradeneeded = function(e) {
-        db = e.target.result;
-        var objStore = db.createObjectStore("my_objectstore");
-        objStore.createIndex("my_index", "");
+      objStore.add("data",  1);
+      objStore.add("data2", 2);
+    },
+    function(t, db) {
+      var cursor_rq = cursor_rq_func(db);
 
-        objStore.add("data",  1);
-        objStore.add("data2", 2);
-    };
+      cursor_rq.onsuccess = t.step_func(function(e) {
+        if (!e.target.result) {
+          return;
+        }
+        var cursor = e.target.result;
+        assert_readonly(cursor, 'source');
 
-    function cursor_source(name, stringified_object, cursor_rq) {
-        var cursor;
+        // Direct try
+        assert_true(cursor.source instanceof Object, "source isobject");
+        assert_equals(cursor.source + "", stringified_object, "source");
+        assert_equals(cursor.source.name, name, "name");
 
-        cursor_rq.onsuccess = this.step_func(function(e) {
-            if (!e.target.result) {
-                return;
-            }
-            cursor = e.target.result;
-            assert_readonly(cursor, 'source');
+        cursor.continue();
+      });
 
-            // Direct try
-            assert_true(cursor.source instanceof Object, "source isobject");
-            assert_equals(cursor.source + "", stringified_object, "source");
-            assert_equals(cursor.source.name, name, "name");
+      cursor_rq.transaction.oncomplete = t.step_func(function(e) {
+        t.done();
+      });
 
-            cursor.continue();
-        });
+      cursor_rq.transaction.onerror = t.step_func(function(e) {
+        assert_unreached("Transaction got error. " + (e.target.error ? e.target.error.name : "unknown"));
+      });
+    },
+    test_name
+  );
+}
 
-        cursor_rq.transaction.oncomplete = this.step_func(function(e) {
-            this.done();
-         });
+cursor_source_test(
+  document.title + ' - IDBObjectStore',
+  "my_objectstore",
+  "[object IDBObjectStore]",
+  function(db) { return db.transaction("my_objectstore")
+                          .objectStore("my_objectstore")
+                          .openCursor(); }
+);
 
-        cursor_rq.transaction.onerror = this.step_func(function(e) {
-            assert_unreached("Transaction got error. " + (e.target.error ? e.target.error.name : "unknown"));
-        });
-    }
-
-    open_rq.onsuccess = function() {
-        async_test(document.title + ' - IDBObjectStore').step(function() {
-            cursor_source.call(this, "my_objectstore", "[object IDBObjectStore]", db.transaction("my_objectstore")
-                                                       .objectStore("my_objectstore")
-                                                       .openCursor());
-        });
-
-        async_test(document.title + ' - IDBIndex').step(function() {
-            cursor_source.call(this, "my_index", "[object IDBIndex]", db.transaction("my_objectstore")
-                                                 .objectStore("my_objectstore")
-                                                 .index("my_index")
-                                                 .openCursor());
-        });
-
-        done();
-    };
-
+cursor_source_test(
+  document.title + ' - IDBIndex',
+  "my_index",
+  "[object IDBIndex]",
+  function(db) { return db.transaction("my_objectstore")
+                          .objectStore("my_objectstore")
+                          .index("my_index")
+                          .openCursor(); }
+);
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/idbcursor_iterating.htm
+++ b/IndexedDB/idbcursor_iterating.htm
@@ -13,6 +13,7 @@
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;
+        t.add_cleanup(function() { db.close(); indexedDB.delete(db.name); });
         var objStore = db.createObjectStore("test", { keyPath: "key" });
 
         for (var i = 0; i < 500; i++)
@@ -106,5 +107,3 @@
         });
     };
 </script>
-
-<div id="log"> </div>

--- a/IndexedDB/idbcursor_iterating_objectstore.htm
+++ b/IndexedDB/idbcursor_iterating_objectstore.htm
@@ -18,6 +18,7 @@
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;
+        t.add_cleanup(function() { db.close(); indexedDB.delete(db.name); });
         var objStore = db.createObjectStore("test", {keyPath:"pKey"});
 
         for (var i = 0; i < records.length; i++)
@@ -47,5 +48,3 @@
         });
     };
 </script>
-
-<div id="log"> </div>

--- a/IndexedDB/idbcursor_iterating_objectstore2.htm
+++ b/IndexedDB/idbcursor_iterating_objectstore2.htm
@@ -18,6 +18,7 @@
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;
+        t.add_cleanup(function() { db.close(); indexedDB.delete(db.name); });
         var objStore = db.createObjectStore("test", {keyPath:"pKey"});
 
         for (var i = 0; i < records.length; i++)
@@ -47,5 +48,3 @@
         });
     };
 </script>
-
-<div id="log"> </div>

--- a/IndexedDB/idbindex_getAll.html
+++ b/IndexedDB/idbindex_getAll.html
@@ -2,26 +2,14 @@
 <title>IndexedDB: Test IDBIndex.getAll.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
 <script>
-setup({explicit_done: true});
-
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 var ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
-function doSetup(dbName, dbVersion, onsuccess) {
-  var delete_request = indexedDB.deleteDatabase(dbName);
-  delete_request.onerror = function() {
-    assert_unreached('deleteDatabase should not fail');
-  };
-  delete_request.onsuccess = function(e) {
-    var req = indexedDB.open(dbName, dbVersion);
-    req.onsuccess = onsuccess;
-    req.onerror = function() {
-      assert_unreached('open should not fail');
-    };
-    req.onupgradeneeded = function(evt) {
-      var connection = evt.target.result;
-
+function getall_test(func, name) {
+  indexeddb_test(
+    function(t, connection, tx) {
       var store = connection.createObjectStore('generated',
             {autoIncrement: true, keyPath: 'id'});
       var index = store.createIndex('test_idx', 'upper');
@@ -61,8 +49,10 @@ function doSetup(dbName, dbVersion, onsuccess) {
 
       store = connection.createObjectStore('empty', null);
       index = store.createIndex('test_idx', 'upper');
-    };
-  };
+    },
+    func,
+    name
+  );
 }
 
 function createGetAllRequest(t, storeName, connection, range, maxCount) {
@@ -74,9 +64,7 @@ function createGetAllRequest(t, storeName, connection, range, maxCount) {
     return req;
 }
 
-doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
-    var connection = evt.target.result;
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection, 'C');
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
@@ -87,7 +75,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Single item get');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'empty', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, [],
@@ -96,7 +84,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Empty object store');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection);
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
@@ -107,7 +95,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Get all keys');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection, undefined,
                                     10);
       req.onsuccess = t.step_func(function(evt) {
@@ -119,7 +107,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'maxCount=10');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('G', 'M'));
       req.onsuccess = t.step_func(function(evt) {
@@ -130,7 +118,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Get bound range');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('G', 'M'), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -142,7 +130,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Get bound range with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
           IDBKeyRange.bound('G', 'K', false, true));
       req.onsuccess = t.step_func(function(evt) {
@@ -154,7 +142,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Get upper excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
           IDBKeyRange.bound('G', 'K', true, false));
       req.onsuccess = t.step_func(function(evt) {
@@ -166,7 +154,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Get lower excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'generated',
           connection, IDBKeyRange.bound(4, 15), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -177,7 +165,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Get bound range (generated) with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line',
           connection, "Doesn't exist");
       req.onsuccess = t.step_func(function(evt) {
@@ -188,7 +176,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Non existent key');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
           undefined, 0);
       req.onsuccess = t.step_func(function(evt) {
@@ -200,7 +188,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'maxCount=0');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line-not-unique', connection,
                                     'first');
       req.onsuccess = t.step_func(function(evt) {
@@ -212,7 +200,7 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       });
     }, 'Retrieve multiEntry key');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line-multi', connection,
                                     'vowel');
       req.onsuccess = t.step_func(function(evt) {
@@ -224,9 +212,5 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
           t.done();
       });
     }, 'Retrieve one key multiple values');
-
-    // Explicit done needed in case async_test body fails synchronously.
-    done();
-});
 
 </script>

--- a/IndexedDB/idbindex_getAllKeys.html
+++ b/IndexedDB/idbindex_getAllKeys.html
@@ -2,25 +2,14 @@
 <title>IndexedDB: Test IDBIndex.getAllKeys.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
 <script>
-setup({explicit_done: true});
 
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
-function doSetup(dbName, dbVersion, onsuccess) {
-  var delete_request = indexedDB.deleteDatabase(dbName);
-  delete_request.onerror = function() {
-    assert_unreached('deleteDatabase should not fail');
-  };
-  delete_request.onsuccess = function(e) {
-    var req = indexedDB.open(dbName, dbVersion);
-    req.onsuccess = onsuccess;
-    req.onerror = function() {
-      assert_unreached('open should not fail');
-    };
-    req.onupgradeneeded = function(evt) {
-      var connection = evt.target.result;
-
+function getall_test(func, name) {
+  indexeddb_test(
+    function(t, connection, tx) {
       var store = connection.createObjectStore('generated',
             {autoIncrement: true, keyPath: 'id'});
       var index = store.createIndex('test_idx', 'upper');
@@ -51,8 +40,10 @@ function doSetup(dbName, dbVersion, onsuccess) {
 
       store = connection.createObjectStore('empty', null);
       index = store.createIndex('test_idx', 'upper');
-    };
-  };
+    },
+    func,
+    name
+  );
 }
 
 function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
@@ -64,9 +55,7 @@ function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
     return req;
 }
 
-doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
-    var connection = evt.target.result;
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection, 'C');
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
@@ -75,7 +64,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Single item get');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'empty', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, [],
@@ -84,7 +73,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Empty object store');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, alphabet,
@@ -93,7 +82,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Get all keys');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'generated', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
@@ -104,7 +93,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Get all generated keys');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection, undefined,
                                     10);
       req.onsuccess = t.step_func(function(evt) {
@@ -115,7 +104,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'maxCount=10');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('G', 'M'));
       req.onsuccess = t.step_func(function(evt) {
@@ -126,7 +115,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Get bound range');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('G', 'M'), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -137,7 +126,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Get bound range with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
           IDBKeyRange.bound('G', 'K', false, true));
       req.onsuccess = t.step_func(function(evt) {
@@ -148,7 +137,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Get upper excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
           IDBKeyRange.bound('G', 'K', true, false));
       req.onsuccess = t.step_func(function(evt) {
@@ -159,7 +148,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Get lower excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'generated',
           connection, IDBKeyRange.bound(4, 15), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -169,7 +158,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Get bound range (generated) with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line',
           connection, "Doesn't exist");
       req.onsuccess = t.step_func(function(evt) {
@@ -180,7 +169,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'Non existent key');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
           undefined, 0);
       req.onsuccess = t.step_func(function(evt) {
@@ -190,7 +179,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
     }, 'maxCount=0');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line-multi', connection,
                                         'vowel');
       req.onsuccess = t.step_func(function(evt) {
@@ -199,9 +188,5 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
       req.onerror = t.unreached_func('getAllKeys request should succeed');
     }, 'Retrieve multiEntry keys');
-
-    // Explicit done needed in case async_test body fails synchronously.
-    done();
-});
 
 </script>

--- a/IndexedDB/idbobjectstore_getAll.html
+++ b/IndexedDB/idbobjectstore_getAll.html
@@ -2,25 +2,14 @@
 <title>IndexedDB: Test IDBObjectStore.getAll.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
 <script>
-setup({explicit_done: true});
 
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
-function doSetup(dbName, dbVersion, onsuccess) {
-  var delete_request = indexedDB.deleteDatabase(dbName);
-  delete_request.onerror = function() {
-    assert_unreached('deleteDatabase should not fail');
-  };
-  delete_request.onsuccess = function(e) {
-    var req = indexedDB.open(dbName, dbVersion);
-    req.onsuccess = onsuccess;
-    req.onerror = function() {
-      assert_unreached('open should not fail');
-    };
-    req.onupgradeneeded = function(evt) {
-      var connection = evt.target.result;
-
+function getall_test(func, name) {
+  indexeddb_test(
+    function(t, connection, tx) {
       var store = connection.createObjectStore('generated',
             {autoIncrement: true, keyPath: 'id'});
       alphabet.forEach(function(letter) {
@@ -33,8 +22,10 @@ function doSetup(dbName, dbVersion, onsuccess) {
       });
 
       store = connection.createObjectStore('empty', null);
-    };
-  };
+    },
+    func,
+    name
+  );
 }
 
 function createGetAllRequest(t, storeName, connection, range, maxCount) {
@@ -45,9 +36,7 @@ function createGetAllRequest(t, storeName, connection, range, maxCount) {
     return req;
 }
 
-doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
-    var connection = evt.target.result;
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection, 'c');
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, ['value-c']);
@@ -55,7 +44,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Single item get');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'generated', connection, 3);
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
@@ -67,7 +56,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Single item get (generated key)');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'empty', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, [],
@@ -76,7 +65,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'getAll on empty object store');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
@@ -85,7 +74,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Get all values');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection, undefined,
                                     10);
       req.onsuccess = t.step_func(function(evt) {
@@ -95,7 +84,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Test maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'm'));
       req.onsuccess = t.step_func(function(evt) {
@@ -105,7 +94,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Get bound range');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'm'), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -115,7 +104,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Get bound range with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'k', false, true));
       req.onsuccess = t.step_func(function(evt) {
@@ -125,7 +114,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Get upper excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'k', true, false));
       req.onsuccess = t.step_func(function(evt) {
@@ -135,7 +124,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Get lower excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'generated', connection,
                                     IDBKeyRange.bound(4, 15), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -147,7 +136,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       });
     }, 'Get bound range (generated) with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection,
                                     "Doesn't exist");
       req.onsuccess = t.step_func(function(evt) {
@@ -158,7 +147,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       req.onerror = t.unreached_func('getAll request should succeed');
     }, 'Non existent key');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllRequest(t, 'out-of-line', connection, undefined, 0);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
@@ -166,9 +155,5 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
           t.done();
       });
     }, 'zero maxCount');
-
-    // Explicit done needed in case async_test body fails synchronously.
-    done();
-});
 
 </script>

--- a/IndexedDB/idbobjectstore_getAllKeys.html
+++ b/IndexedDB/idbobjectstore_getAllKeys.html
@@ -2,25 +2,14 @@
 <title>IndexedDB: Test IDBObjectStore.getAllKeys.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
 <script>
-setup({explicit_done: true});
 
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
-function doSetup(dbName, dbVersion, onsuccess) {
-  var delete_request = indexedDB.deleteDatabase(dbName);
-  delete_request.onerror = function() {
-    assert_unreached('deleteDatabase should not fail');
-  };
-  delete_request.onsuccess = function(e) {
-    var req = indexedDB.open(dbName, dbVersion);
-    req.onsuccess = onsuccess;
-    req.onerror = function() {
-      assert_unreached('open should not fail');
-    };
-    req.onupgradeneeded = function(evt) {
-      var connection = evt.target.result;
-
+function getall_test(func, name) {
+  indexeddb_test(
+    function(t, connection, tx) {
       var store = connection.createObjectStore('generated',
             {autoIncrement: true, keyPath: 'id'});
       alphabet.forEach(function(letter) {
@@ -33,8 +22,10 @@ function doSetup(dbName, dbVersion, onsuccess) {
       });
 
       store = connection.createObjectStore('empty', null);
-    };
-  };
+    },
+    func,
+    name
+  );
 }
 
 function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
@@ -45,9 +36,7 @@ function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
     return req;
 }
 
-doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
-    var connection = evt.target.result;
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection, 'c');
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, ['c']);
@@ -55,7 +44,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Single item get');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'generated', connection, 3);
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
@@ -65,7 +54,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Single item get (generated key)');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'empty', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, [],
@@ -75,7 +64,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'getAllKeys on empty object store');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, alphabet);
@@ -83,7 +72,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Get all values');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection, undefined,
                                     10);
       req.onsuccess = t.step_func(function(evt) {
@@ -92,7 +81,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Test maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'm'));
       req.onsuccess = t.step_func(function(evt) {
@@ -101,7 +90,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Get bound range');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'm'), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -110,7 +99,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Get bound range with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'k', false, true));
       req.onsuccess = t.step_func(function(evt) {
@@ -119,7 +108,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Get upper excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'k', true, false));
       req.onsuccess = t.step_func(function(evt) {
@@ -128,7 +117,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Get lower excluded');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'generated', connection,
                                     IDBKeyRange.bound(4, 15), 3);
       req.onsuccess = t.step_func(function(evt) {
@@ -139,7 +128,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       });
     }, 'Get bound range (generated) with maxCount');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     "Doesn't exist");
       req.onsuccess = t.step_func(function(evt) {
@@ -151,7 +140,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       req.onerror = t.unreached_func('getAllKeys request should succeed');
     }, 'Non existent key');
 
-    async_test(function(t) {
+getall_test(function(t, connection) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection, undefined,
           0);
       req.onsuccess = t.step_func(function(evt) {
@@ -159,9 +148,5 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
           t.done();
       });
     }, 'zero maxCount');
-
-    // Explicit done needed in case async_test body fails synchronously.
-    done();
-});
 
 </script>

--- a/IndexedDB/idbobjectstore_getKey.html
+++ b/IndexedDB/idbobjectstore_getKey.html
@@ -4,17 +4,12 @@
 <meta name=timeout content=long>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
 <script>
 
 function getkey_test(func, name) {
-    return async_test(function(t) {
-        var del = indexedDB.deleteDatabase(name);
-        del.onerror = t.unreached_func('deleteDatabase failed');
-        var open = indexedDB.open(name);
-        open.onerror = t.unreached_func('open failed');
-        open.onupgradeneeded = t.step_func(function() {
-            var db = open.result;
-
+    indexeddb_test(
+        function(t, db, tx) {
             var basic = db.createObjectStore('basic');
             var key_path_store = db.createObjectStore('key path',
                 {keyPath: 'id'});
@@ -30,12 +25,10 @@ function getkey_test(func, name) {
                 key_generator_store.put('value: ' + i);
                 key_generator_and_path_store.put({});
             }
-        });
-        open.onsuccess = t.step_func(function() {
-            var db = open.result;
-            func(t, db);
-        });
-    }, name);
+        },
+        func,
+        name
+    );
 }
 
 getkey_test(function(t, db) {

--- a/IndexedDB/idbobjectstore_openCursor_invalid.htm
+++ b/IndexedDB/idbobjectstore_openCursor_invalid.htm
@@ -4,28 +4,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support.js"></script>
-
 <script>
 
-    var db, open;
-
-    setup(function() {
-        open = indexedDB.open('testdb-' + new Date().getTime());
-        open.onupgradeneeded = function(e) {
-            db = e.target.result;
+indexeddb_test(
+  function(t, db, tx) {
             var objStore = db.createObjectStore("test");
             objStore.createIndex("index", "");
 
             objStore.add("data",  1);
             objStore.add("data2", 2);
-        };
-    },
-    { explicit_done: true });
-
-
-    open.onsuccess = function() {
-
-        async_test(document.title + " - pass something other than number").step(function(e) {
+  },
+  function(t, db, tx) {
             var idx = db.transaction("test").objectStore("test").index("index");
 
             assert_throws("DataError",
@@ -37,14 +26,8 @@
             assert_throws("DataError",
                 function() { idx.openCursor({ lower: "a", lowerOpen: false, upper: null, upperOpen: false }); });
 
-            this.done();
-        });
-
-
-        // Stop blocking the testing system from hereon
-        done();
-    }
-
+            t.done();
+  },
+  document.title + " - pass something other than number"
+);
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/idbobjectstore_openKeyCursor.htm
+++ b/IndexedDB/idbobjectstore_openKeyCursor.htm
@@ -2,26 +2,20 @@
 <title>IDBObjectStore.openKeyCursor()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
 <script>
 function store_test(func, name) {
-    async_test(function(t) {
-        var del = indexedDB.deleteDatabase(name);
-        del.onerror = t.unreached_func("deleteDatabase failed");
-        var open = indexedDB.open(name);
-        open.onupgradeneeded = t.step_func(function() {
-            var db = open.result;
-            var store = db.createObjectStore("store");
-            for (var i = 0; i < 10; ++i) {
-                store.put("value: " + i, i);
-            }
-        });
-
-        open.onsuccess = t.step_func(function() {
-            var db = open.result;
-            var tx = db.transaction("store");
-            var store = tx.objectStore("store");
-            func(t, db, tx, store);
-        });
+  indexeddb_test(
+    function(t, db, tx) {
+      var store = db.createObjectStore("store");
+      for (var i = 0; i < 10; ++i) {
+        store.put("value: " + i, i);
+      }
+    },
+    function(t, db) {
+      var tx = db.transaction("store");
+      var store = tx.objectStore("store");
+      func(t, db, tx, store);
     }, name);
 }
 

--- a/IndexedDB/idbrequest-onupgradeneeded.htm
+++ b/IndexedDB/idbrequest-onupgradeneeded.htm
@@ -16,6 +16,10 @@ function upgradeneeded_test(upgrade_func, success_func, error_func, description)
       var open_request = indexedDB.open(dbName);
 
       open_request.onupgradeneeded = t.step_func(function() {
+        t.add_cleanup(function() {
+          open_request.result.close(),
+          indexedDB.deleteDatabase(dbName);
+        });
         upgrade_func(t, open_request);
       });
       open_request.onsuccess = t.step_func(function() {

--- a/IndexedDB/idbtransaction.htm
+++ b/IndexedDB/idbtransaction.htm
@@ -6,41 +6,54 @@
 <script src="support.js"></script>
 
 <script>
-    var db,
-      t = async_test(document.title + " - request gotten by the handler"),
-      open_t = async_test(document.title + " - request returned by open()"),
+async_test(function(t) {
+  var open_rq = indexedDB.open("idbtransaction-" + document.location + t.name);
 
-    open_rq = indexedDB.open("idbtransaction-" + new Date().getTime() + Math.random());
+  open_rq.onblocked = t.unreached_func('open_rq.onblocked');
+  open_rq.onerror = t.unreached_func('open_rq.onerror');
 
-    open_t.step(function() {
-        assert_equals(open_rq.transaction, null, "IDBOpenDBRequest.transaction");
-        assert_equals(open_rq.source, null, "IDBOpenDBRequest.source");
-        assert_equals(open_rq.readyState, "pending", "IDBOpenDBRequest.readyState");
-
-        assert_true(open_rq instanceof IDBOpenDBRequest, "open_rq instanceof IDBOpenDBRequest");
-        assert_equals(open_rq + "", "[object IDBOpenDBRequest]", "IDBOpenDBRequest (open_rq)");
-
-        open_t.done();
+  open_rq.onupgradeneeded = t.step_func(function(e) {
+    t.add_cleanup(function() {
+      open_rq.onerror = function(e) {
+        e.preventDefault();
+      };
+      open_rq.result.close();
+      indexedDB.deleteDatabase(open_rq.result.name);
     });
 
-    open_rq.onupgradeneeded = t.step_func(function(e) {
-        assert_equals(e.target, open_rq, "e.target is reusing the same IDBOpenDBRequest");
-        assert_equals(e.target.transaction, open_rq.transaction, "IDBOpenDBRequest.transaction");
+    assert_equals(e.target, open_rq, "e.target is reusing the same IDBOpenDBRequest");
+    assert_equals(e.target.transaction, open_rq.transaction, "IDBOpenDBRequest.transaction");
 
-        assert_true(e.target.transaction instanceof IDBTransaction, "transaction instanceof IDBTransaction");
-        t.done();
+    assert_true(e.target.transaction instanceof IDBTransaction, "transaction instanceof IDBTransaction");
+    t.done();
+  });
+
+}, document.title + " - request gotten by the handler");
+
+async_test(function(t) {
+  var open_rq = indexedDB.open("idbtransaction-" + document.location + t.name);
+
+  assert_equals(open_rq.transaction, null, "IDBOpenDBRequest.transaction");
+  assert_equals(open_rq.source, null, "IDBOpenDBRequest.source");
+  assert_equals(open_rq.readyState, "pending", "IDBOpenDBRequest.readyState");
+
+  assert_true(open_rq instanceof IDBOpenDBRequest, "open_rq instanceof IDBOpenDBRequest");
+  assert_equals(open_rq + "", "[object IDBOpenDBRequest]", "IDBOpenDBRequest (open_rq)");
+
+  open_rq.onblocked = t.unreached_func('open_rq.onblocked');
+  open_rq.onerror = t.unreached_func('open_rq.onerror');
+
+  open_rq.onupgradeneeded = t.step_func(function() {
+    t.add_cleanup(function() {
+      open_rq.onerror = function(e) {
+        e.preventDefault();
+      };
+      open_rq.result.close();
+      indexedDB.deleteDatabase(open_rq.result.name);
     });
+    t.done();
+  });
 
+}, document.title + " - request returned by open()");
 
-    // Not plausible conditions...
-    function fail_helper(name) {
-        return function() {
-            t.step(function() { assert_unreached(name); });
-            open_t.step(function() { assert_unreached(name); });
-        };
-    }
-    open_rq.onblocked = fail_helper('open_rq.onblocked');
-    open_rq.onerror = fail_helper('open_rq.onerror');
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/support.js
+++ b/IndexedDB/support.js
@@ -106,30 +106,34 @@ function assert_key_equals(actual, expected, description) {
 
 function indexeddb_test(upgrade_func, open_func, description, options) {
   async_test(function(t) {
-    var options = Object.assign({upgrade_will_abort: false}, options);
+    options = Object.assign({upgrade_will_abort: false}, options);
     var dbname = document.location + '-' + t.name;
     var del = indexedDB.deleteDatabase(dbname);
     del.onerror = t.unreached_func('deleteDatabase should succeed');
     var open = indexedDB.open(dbname, 1);
-    if (!options.upgrade_will_abort) {
-      open.onsuccess = t.unreached_func('open should not succeed');
-    } else {
-      open.onerror = t.unreached_func('open should succeed');
-    }
     open.onupgradeneeded = t.step_func(function() {
       var db = open.result;
-      var tx = open.transaction;
-      upgrade_func(t, db, tx);
-    });
-    open.onsuccess = t.step_func(function() {
-      var db = open.result;
       t.add_cleanup(function() {
+        // If open didn't succeed already, ignore the error.
+        open.onerror = function(e) {
+          e.preventDefault();
+        };
         db.close();
         indexedDB.deleteDatabase(db.name);
       });
-      if (open_func)
-        open_func(t, db);
+      var tx = open.transaction;
+      upgrade_func(t, db, tx);
     });
+    if (options.upgrade_will_abort) {
+      open.onsuccess = t.unreached_func('open should not succeed');
+    } else {
+      open.onerror = t.unreached_func('open should succeed');
+      open.onsuccess = t.step_func(function() {
+        var db = open.result;
+        if (open_func)
+          open_func(t, db);
+      });
+    }
   }, description);
 }
 


### PR DESCRIPTION
Tests that use common helpers (indexedb_test, createdb, etc) get
this for free, but tests that don't need add_cleanup() steps or to
be converted to use a helper.

Also addressed problems in indexeddb_test from support.js:

* `var options` was shadowing the `options` argument
* logic for using the upgrade_will_abort was inverted
* moved add_cleanup() call to cover cases where the upgrade aborts

https://github.com/w3c/web-platform-tests/issues/4560

Review-Url: https://codereview.chromium.org/2820393003
Cr-Commit-Position: refs/heads/master@{#466356}

